### PR TITLE
Don't assume that /bin/sh is the same as /bin/bash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,8 @@
 # copy of the original game.
 BUILD_VANILLA = true
 
+SHELL := /bin/bash
+
 CC = wla-gb
 LD = wlalink
 PYTHON = python2

--- a/fixbuild.sh
+++ b/fixbuild.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Check which build mode the makefile uses, and rearrange the build directories 
 # accordingly.

--- a/swapbuild.sh
+++ b/swapbuild.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Change the build mode from "vanilla" (exact copy) to fully modifiable, or
 # vice versa.


### PR DESCRIPTION
Hi, it seems your scripts all assume that /bin/sh is the same as /bin/bash. I'm not sure how it is on other linux systems, but in my VM, /bin/sh is not bash. As a result, trying to build gives me a lot of errors about `[[` and stuff.

This fixes that by specifying bash explicitly.