### PR TITLE
Fix comment on green ring damage taken modifier

### DIFF
--- a/main.s
+++ b/main.s
@@ -60200,7 +60200,7 @@ linkUpdateDamageToApplyForRings:
 	sra a			; $4690
 	jr @writeDamageToApply		; $4692
 
-; Green ring: damage /= 1.5
+; Green ring: damage *= 0.75
 @greenRing:
 	ld a,b			; $4694
 	cpl			; $4695


### PR DESCRIPTION
Green ring multiplies damage taken by 3 and divides by 4.



pull request body text auto-generated from commit messages always comes across as very blunt