### PR TITLE
Explain purpose of treasure $58, given with bomb flower

### DIFF
--- a/constants/treasure.s
+++ b/constants/treasure.s
@@ -99,7 +99,7 @@
 	TREASURE_BOOK_OF_SEALS		db ; $55
 	TREASURE_56			db ; $56
 	TREASURE_57			db ; $57
-	TREASURE_58			db ; $58: relates to bomb flower?
+	TREASURE_58			db ; $58: lower half of bomb flower (uses different palette)
 	TREASURE_GORON_LETTER		db ; $59
 	TREASURE_LAVA_JUICE		db ; $5a
 	TREASURE_BROTHER_EMBLEM		db ; $5b
@@ -132,7 +132,7 @@
 	TREASURE_55			db ; $55
 	TREASURE_56			db ; $56
 	TREASURE_57			db ; $57
-	TREASURE_58			db ; $58: relates to bomb flower?
+	TREASURE_58			db ; $58: lower half of bomb flower (uses different palette)
 
 	; The remainder appear as seeds in seed satchel/slingshot, but that probably
 	; doesn't mean anything. These may not be valid treasures.


### PR DESCRIPTION
The bomb flower graphic uses two different palettes in the inventory, so each treasure ID is used to draw half of it. Apparently.