### PR TITLE
Add message before md5sum verification

### DIFF
--- a/tools/build/verify-checksum.sh
+++ b/tools/build/verify-checksum.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+echo "Comparing to vanilla ROM MD5 checksum..."
 if [[ "$1" == "seasons" ]]; then
 	md5sum -c $1.md5 2>/dev/null
 	if [[ $? -ne 0 ]]; then


### PR DESCRIPTION
This change should make it more obvious that a failed verification does not mean the build failed.