### PR TITLE
fix compiler error

### DIFF
--- a/code/bank1.s
+++ b/code/bank1.s
@@ -4372,7 +4372,7 @@ calculateRoomEdge:
 	ld a,(wRoomIsLarge)
 	or a
 	jr z,+
-	ldbc (LARGE_ROOM_HEIGHT+1)*16, LARGE_ROOM_WIDTH*16
+	ldbc ((LARGE_ROOM_HEIGHT+1)*16), (LARGE_ROOM_WIDTH*16)
 +
 	ld hl,wRoomEdgeY
 	ld (hl),b


### PR DESCRIPTION
this fixes the following error: `code/bank1.s:4375: COMPUTE_STACK: Multiply is missing an operand.`
which occurs on the current version of `wla-gb` 10.2